### PR TITLE
BYD usable defaults, double scaling and right-click gesture.

### DIFF
--- a/drivers/input/mouse/byd.c
+++ b/drivers/input/mouse/byd.c
@@ -52,7 +52,7 @@ static const unsigned char byd_init_param[] = {
 
 	0xd3, 0x01,  // set right-handedness
 	0xd0, 0x00,  // reset button
-	0xd0, 0x07,  // send click in both corners as separate gestures
+	0xd0, 0x06,  // send click in both corners as separate gestures
 	0xd4, 0x02,  // disable tapping.
 	0xd5, 0x03,  // tap and drag off
 	0xd7, 0x04,  // edge scrolling off

--- a/drivers/input/mouse/byd.c
+++ b/drivers/input/mouse/byd.c
@@ -37,7 +37,7 @@
 #define BYD_CMD_PAIR(c)		((1 << 12) | (c))
 #define BYD_CMD_PAIR_R(r,c)	((1 << 12) | (r << 8) | (c))
 
-#define DEBUG 1
+#define DEBUG 0
 
 struct byd_model_info {
 	char name[16];


### PR DESCRIPTION
I shared this BYD driver with Purism developers and they've made a few changes which are included in this pull request.
- Explain config commands. Set a more usable set of defaults.
- Enable double-scaling which keeps us from jumping around on slow movement.
- Make only right-click a gesture, let click anywhere else be a normal click.
